### PR TITLE
Refactor toggle modal

### DIFF
--- a/src/components/modal/index.js
+++ b/src/components/modal/index.js
@@ -3,9 +3,9 @@ import { useEffect } from "preact/hooks";
 
 import { Backdrop, ModalWrapper, ModalContainer } from "./styled";
 
-const Modal = ({ onRequestClose, isModalOpen, children }) => {
+const Modal = ({ onRequestClose, children }) => {
   const onKeyDown = (event) => {
-    if (event.keyCode === 27 && isModalOpen) {
+    if (event.keyCode === 27) {
       // Close the modal when the Escape key is pressed
       onRequestClose();
     }
@@ -34,7 +34,6 @@ const Modal = ({ onRequestClose, isModalOpen, children }) => {
 };
 
 Modal.defaultProps = {
-  isModalOpen: false,
   onRequestClose: () => {},
 };
 

--- a/src/containers/widget/index.js
+++ b/src/containers/widget/index.js
@@ -15,6 +15,12 @@ const Widget = ({ showModal, screenName, imageSrc, widgetTitle }) => {
   const [isModalOpen, setModalIsOpen] = useState(showModal);
   const [currentScreen, setCurrentScreen] = useState(screenName);
 
+  const closeModal = () => {
+    setModalIsOpen(false);
+  }
+  const openModal = () => {
+    setModalIsOpen(true);
+  }
   const toggleModalVisibility = () => {
     setModalIsOpen(!isModalOpen);
   };
@@ -35,7 +41,7 @@ const Widget = ({ showModal, screenName, imageSrc, widgetTitle }) => {
             imageSrc={imageSrc}
             title={widgetTitle}
             onDonateClick={handleDonateClick}
-            onRequestClose={toggleModalVisibility}
+            onRequestClose={closeModal}
           />
         );
       case "donate-screen":
@@ -43,7 +49,7 @@ const Widget = ({ showModal, screenName, imageSrc, widgetTitle }) => {
           <DonateScreen
             title={widgetTitle}
             onNextClick={handleDonateNextClick}
-            onRequestClose={toggleModalVisibility}
+            onRequestClose={closeModal}
           />
         );
       default:
@@ -56,10 +62,7 @@ const Widget = ({ showModal, screenName, imageSrc, widgetTitle }) => {
       <CacheProvider value={StyledCache("fourohtwo", ".fourohtwo-widget")}>
         <Button buttonClick={toggleModalVisibility} />
         {isModalOpen && (
-          <Modal
-            isModalOpen={isModalOpen}
-            onRequestClose={toggleModalVisibility}
-          >
+          <Modal onRequestClose={closeModal}>
             {renderModalContent()}
           </Modal>
         )}


### PR DESCRIPTION
This way we do not need to pass in the isModalOpen state. We can simply always call closeModal.