### PR TITLE
Allow user to pass attributes to global exposed method

### DIFF
--- a/src/components/modal/styled.js
+++ b/src/components/modal/styled.js
@@ -57,7 +57,7 @@ const BottomCirlceWrapper = styled.div`
 
 export const BottomCircle = () => (
   <BottomCirlceWrapper>
-    <svg width="180" height="114" viewBox="0 0 180 114" fill="none">
+    <svg width="160" height="114" viewBox="0 0 160 114" fill="none">
       <circle cx="178" cy="178" r="178" fill="#4761FB" fill-opacity="0.07" />
     </svg>
   </BottomCirlceWrapper>

--- a/src/containers/widget/index.js
+++ b/src/containers/widget/index.js
@@ -21,6 +21,15 @@ class Widget extends Component {
     super(props);
 
     this.state = {
+      // storing props in local state
+      apiToken: props.apiToken,
+      currency: props.currency,
+      apiBaseUrl: props.apiBaseUrl,
+      widgetTitle: props.widgetTitle,
+      paymentOptions: props.paymentOptions,
+      welcomeMessage: props.welcomeMessage,
+      enableEmailSubscription: props.enableEmailSubscription,
+
       invoiceDetails: null,
       fetchingInvoiceState: false,
       isModalOpen: props.showModal,
@@ -36,6 +45,28 @@ class Widget extends Component {
 
   componentWillUnmount() {
     this.setDefaults();
+  }
+
+  componentDidMount() {
+    const {
+      apiToken,
+      currency,
+      apiBaseUrl,
+      widgetTitle,
+      paymentOptions,
+      welcomeMessage,
+      enableEmailSubscription,
+    } = this.props;
+
+    this.setState({
+      apiToken: apiToken,
+      currency: currency,
+      apiBaseUrl: apiBaseUrl,
+      widgetTitle: widgetTitle,
+      paymentOptions: paymentOptions,
+      welcomeMessage: welcomeMessage,
+      enableEmailSubscription: enableEmailSubscription,
+    });
   }
 
   setDefaults = () => {
@@ -57,7 +88,12 @@ class Widget extends Component {
     });
   };
 
-  openWidget = () => this.openModal();
+  openWidget = (attributes) => {
+    this.setState({
+      ...attributes,
+      isModalOpen: true,
+    });
+  };
 
   handleDonateClick = () => {
     this.setState({
@@ -98,12 +134,13 @@ class Widget extends Component {
     const {
       currency,
       widgetTitle,
+      currentScreen,
+      invoiceDetails,
       welcomeMessage,
       paymentOptions,
+      fetchingInvoiceState,
       enableEmailSubscription,
-    } = this.props;
-
-    const { currentScreen, invoiceDetails, fetchingInvoiceState } = this.state;
+    } = this.state;
 
     switch (currentScreen) {
       case "welcome-screen":
@@ -137,7 +174,7 @@ class Widget extends Component {
     }
   };
 
-  render({ widgetTitle }, { isModalOpen }) {
+  render({}, { widgetTitle, isModalOpen }) {
     return (
       <WidgetWrapper>
         <CacheProvider value={StyledCache("fourohtwo", ".fourohtwo-widget")}>

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -21,6 +21,9 @@
         }
       </script>
     </div>
+
     <script async src="/bundle.js"></script>
+
+    <a href="javascript:window.area402.openWidget({ currency: '€', showModal: false, paymentOptions: [1, 2, 5, 10], widgetTitle: 'Area 402 Widget', enableEmailSubscription: false, apiBaseUrl: 'https://area402.herokuapp.com', welcomeMessage: 'Lorem Ipsum has been the industry\'s standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.', apiToken: 'UrLnHR1DKN3eiAXefkT9Lm2R' })">Click Me!!</button>
   </body>
 </html>


### PR DESCRIPTION
With this PR, the user can pass attributes to the `window.area402.openWidget` (like shown below) function instead of passing it in the script tag for the widget props.

```html
<a href="javascript:window.area402.openWidget({ currency: '€', showModal: false, paymentOptions: [1, 2, 5, 10], widgetTitle: 'Area 402 Widget', enableEmailSubscription: false, apiBaseUrl: 'https://area402.herokuapp.com', welcomeMessage: 'Lorem Ipsum has been the industry\'s standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.', apiToken: 'UrLnHR1DKN3eiAXefkT9Lm2R' })">Click Me!!</a>
```

Closes #60 